### PR TITLE
added package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+    "name": "CordovaYoutubeVideoPlayer",
+    "version": "1.0.1",
+    "description": "Play Youtube Videos in a native Video Player on Android & iOS.",
+    "cordova": {
+        "id": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
+        "platforms": [
+            "ios",
+            "android"
+        ]
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Glitchbone/CordovaYoutubeVideoPlayer.git"
+    },
+    "keywords": [
+        "video",
+        "youtube",
+        "videoplayer"
+    ],
+    "engines": [{
+        "name": "cordova",
+        "version": ">=3.0.0"
+    }],
+    "author": "Adrien Glitchbone - Bunker Palace SA",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/Glitchbone/CordovaYoutubeVideoPlayer/issues"
+    },
+    "homepage": "https://github.com/Glitchbone/CordovaYoutubeVideoPlayer#readme"
+}


### PR DESCRIPTION
Added package.json.
As from [release notes for Apache Cordova 7.0.0](https://cordova.apache.org/news/2017/05/04/cordova-7.html):

> Platforms and plugins are now required to have a package.json file.
